### PR TITLE
Added extra method for validating an already retrieved refresh_token

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "play-googleopenconnect"
 
 organization := "com.lunatech"
 
-version := "2.5.0"
+version := "2.6.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 


### PR DESCRIPTION
An extra method for validating that an access token is valid by retrieving TokenInfo from Google - if response is invalid, revoke the token.

Method is used by the Vacation webapp to validate that a refresh token obtained by the Android Aggregator app is valid

Flow: 
- Android Aggregator app obtains refresh token
- Android requests a session from Vacation webapp using the refresh token
- Vacation verifies the token by calling `getUserFromToken`
- if there are errors, the token is revoked 
- if the refresh token is correct, Vacation sends an encoded session header to the Android app `Ok("{\"success\": true}").withSession("email" -> authResult.email, "token" -> authResult.token, "ttl" -> ttl)`
- on subsequent requests, the Android app will send the session header as "authentication"

**Note**: increased the library version to 2.6.0, but all other apps can continue using 2.5.0 if they want to 