### PR TITLE
feat: introduce cross building for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := "2.13.11"
 
-crossScalaVersions := Seq("2.12.18", "2.13.11")
+crossScalaVersions := Seq("2.13.11", "3.3.0")
 
 libraryDependencies ++= Seq(
   ws, guice,
@@ -19,10 +19,3 @@ libraryDependencies ++= Seq(
 ThisBuild / versionScheme := Some("semver-spec")
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
-
-githubOwner := "lunatech-labs"
-githubRepository := "lunatech-play-googleopenconnect"
-githubTokenSource := TokenSource.Or(
-  TokenSource.Environment("GITHUB_TOKEN"), // Injected during a github workflow for publishing
-  TokenSource.Environment("SHELL"),  // safe to assume this will be set in all our devs environments, usually /bin/bash, doesn't matter what it is to prevent local errors
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,2 @@
-// Comment to get more information during initialization
-logLevel := Level.Warn
-
-// The Typesafe repository 
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
-
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
-
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
-
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M6")


### PR DESCRIPTION
This also drops it for Scala 2.12 and makes a few other changes around github packages to instead prepare to just release on maven central. This will make it easier for other things (like the vacation app) to just pull them down like other artifacts and not need to worry about the extra repository