### PR TITLE
fix: allow for tags with out v

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,5 +15,6 @@ libraryDependencies ++= Seq(
 )
 
 ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / dynverVTagPrefix := false
 
 Global / onChangedBuildSource := ReloadOnSourceChanges


### PR DESCRIPTION
By default it looks for a tag prefixed with `v`, but since we don't have
that it seemed to just think it was 0.0.0<hash> which we don't want.
